### PR TITLE
Add repository registry for IFT ecosystem

### DIFF
--- a/content/resources/Github.md
+++ b/content/resources/Github.md
@@ -5,7 +5,7 @@ tags:
 
 The IFT leverages github massively throughout for a myriad of reasons. This document will attempt to catalog how. 
 
-TODO - lol
+> [!tip] For a detailed, browsable map of all repositories, see the [[resources/repo-registry/index|Repository Registry]].
 
 - We have an Enterprise license for security purposes. I'm not sure what else that provides us
 - There is currently a github reorg proposal being drafted found here (TODO) since the [[Logos Launch Strategy]] was released. This should drastically clean some of the things up, although I expect some historical baggage to remain. 
@@ -16,3 +16,5 @@ TODO - lol
 - [logos-messaging](https://github.com/logos-messaging) - Formerly Waku
 - [logos-storage](https://github.com/logos-storage) - Formerly Codex
 - [acid-info](https://github.com/acid-info)
+- [vacp2p](https://github.com/vacp2p) - Protocol research (vac.dev)
+- [logos-blockchain](https://github.com/logos-blockchain) - Blockchain implementations

--- a/content/resources/repo-registry/anoncomms-pm.md
+++ b/content/resources/repo-registry/anoncomms-pm.md
@@ -1,0 +1,21 @@
+---
+title: anoncomms-pm
+description: Anonymous communications project management and milestone tracking
+tags: [repo, repo-active, org-logos-co, component-messaging, audience-dev, audience-researcher]
+aliases: [anoncomms-pm, anoncomms]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/anoncomms-pm](https://github.com/logos-co/anoncomms-pm) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | Markdown |
+
+Project management repository for anonymous communications initiatives. Tracks milestones, deliverables, and coordination for privacy-preserving messaging features.
+
+## Related repos
+
+- [[libchat]] — chat library being enhanced with anonymous features
+- [[de-mls]] — encryption protocol for anonymous group messaging
+- [[logos-lez-rln]] — rate limiting for anonymous messaging

--- a/content/resources/repo-registry/assembly.md
+++ b/content/resources/repo-registry/assembly.md
@@ -1,0 +1,21 @@
+---
+title: assembly
+description: This repo — coordination hub and knowledge base for Logos
+tags: [repo, repo-active, org-logos-co, component-docs, audience-dev, audience-community]
+aliases: [assembly, praxis]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/assembly](https://github.com/logos-co/assembly) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | Markdown / TypeScript (Quartz) |
+
+The coordination hub for the Logos project (this site). A Quartz-based knowledge wiki tracking alignment, resources, content, and coordination across the ecosystem. Feeds into RAG systems for AI assistants.
+
+## Related repos
+
+- [[logos-docs]] — official documentation (complementary to this coordination site)
+- [[roadmap]] — project roadmap referenced from here
+- [[rfc-index]] — specs referenced from here

--- a/content/resources/repo-registry/chat-proto.md
+++ b/content/resources/repo-registry/chat-proto.md
@@ -1,0 +1,20 @@
+---
+title: chat-proto
+description: Protobuf definitions for the Logos chat protocol
+tags: [repo, repo-active, org-logos-messaging, component-messaging, audience-dev]
+aliases: [chat-proto, chat_proto]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-messaging/chat_proto](https://github.com/logos-messaging/chat_proto) |
+| **Status** | Active |
+| **Org** | logos-messaging |
+| **Language** | Protobuf |
+
+Protobuf definitions for the Logos chat protocol. Defines message formats, service interfaces, and data structures used across the messaging stack.
+
+## Related repos
+
+- [[libchat]] — primary consumer of these protocol definitions
+- [[rfc-index]] — formal specification the protos implement

--- a/content/resources/repo-registry/data-docs.md
+++ b/content/resources/repo-registry/data-docs.md
@@ -1,0 +1,19 @@
+---
+title: data-docs
+description: Data documentation for the IFT ecosystem
+tags: [repo, repo-active, org-status-im, component-docs, component-infra, audience-ops]
+aliases: [data-docs]
+---
+
+| | |
+|---|---|
+| **GitHub** | [status-im/data-docs](https://github.com/status-im/data-docs) |
+| **Status** | Active |
+| **Org** | status-im |
+| **Language** | Markdown |
+
+Documentation for data systems, schemas, pipelines, and analytics across the IFT ecosystem.
+
+## Related repos
+
+- [[infra-bi]] — BI systems documented here

--- a/content/resources/repo-registry/de-mls.md
+++ b/content/resources/repo-registry/de-mls.md
@@ -1,0 +1,22 @@
+---
+title: de-mls
+description: Decentralized MLS (Messaging Layer Security) protocol implementation
+tags: [repo, repo-active, org-vacp2p, component-messaging, audience-dev, audience-researcher, lang-rust]
+aliases: [de-mls, demls]
+---
+
+| | |
+|---|---|
+| **GitHub** | [vacp2p/de-mls](https://github.com/vacp2p/de-mls) |
+| **Status** | Active |
+| **Org** | vacp2p |
+| **Language** | Rust |
+
+Decentralized MLS (Messaging Layer Security) protocol implementation. Provides end-to-end encrypted group messaging with forward secrecy and post-compromise security in a decentralized context.
+
+## Related repos
+
+- [[libchat]] — chat library integrating de-MLS for group encryption
+- [[anoncomms-pm]] — anonymous communications project using this protocol
+- [[rfc-index]] — MLS protocol specifications
+- [[zerokit]] — ZK primitives potentially used alongside MLS

--- a/content/resources/repo-registry/ift-weekly-news.md
+++ b/content/resources/repo-registry/ift-weekly-news.md
@@ -1,0 +1,20 @@
+---
+title: ift-weekly-news
+description: IFT weekly news publication
+tags: [repo, repo-active, org-status-im, component-docs, audience-community]
+aliases: [ift-weekly-news, weekly-news]
+---
+
+| | |
+|---|---|
+| **GitHub** | [status-im/ift-weekly-news](https://github.com/status-im/ift-weekly-news) |
+| **Status** | Active |
+| **Org** | status-im |
+| **Language** | Markdown |
+
+Weekly news publication for the Institute of Free Technology. Aggregates updates, announcements, and progress reports across the ecosystem.
+
+## Related repos
+
+- [[logos-press-engine]] — publishing engine for web content
+- [[logos-docs]] — documentation site

--- a/content/resources/repo-registry/index.md
+++ b/content/resources/repo-registry/index.md
@@ -1,0 +1,63 @@
+---
+title: Repository Registry
+description: A navigable map of all IFT repositories across GitHub organizations
+tags:
+  - resources
+  - repo
+---
+
+The IFT / Logos ecosystem spans multiple GitHub organizations and dozens of repositories. This registry provides a centralized, browsable map of what exists, what state it's in, who it's for, and how repos relate to each other.
+
+Each repository has its own page with metadata, a short description, and wiki-links to related repos. The **graph** on the right visualizes how repositories connect to each other. Use **tags** to filter by any dimension.
+
+## Browse by status
+
+| Status | Tag page |
+|--------|----------|
+| Active | [[tags/repo-active]] |
+| Maintenance | [[tags/repo-maintenance]] |
+| Experimental | [[tags/repo-experimental]] |
+| Archived | [[tags/repo-archived]] |
+| Deprecated | [[tags/repo-deprecated]] |
+
+## Browse by organization
+
+| Org | Tag page |
+|-----|----------|
+| logos-co | [[tags/org-logos-co]] |
+| logos-messaging | [[tags/org-logos-messaging]] |
+| logos-storage | [[tags/org-logos-storage]] |
+| status-im | [[tags/org-status-im]] |
+| vacp2p | [[tags/org-vacp2p]] |
+| acid-info | [[tags/org-acid-info]] |
+| logos-blockchain | [[tags/org-logos-blockchain]] |
+
+## Browse by component
+
+| Component | Tag page |
+|-----------|----------|
+| Logos Core | [[tags/component-core]] |
+| Messaging | [[tags/component-messaging]] |
+| Storage | [[tags/component-storage]] |
+| Blockchain | [[tags/component-blockchain]] |
+| UI | [[tags/component-ui]] |
+| Tooling | [[tags/component-tooling]] |
+| Infrastructure | [[tags/component-infra]] |
+| Documentation | [[tags/component-docs]] |
+
+## Browse by audience
+
+| Audience | Tag page |
+|----------|----------|
+| Developers | [[tags/audience-dev]] |
+| Ops / Infrastructure | [[tags/audience-ops]] |
+| Researchers | [[tags/audience-researcher]] |
+| Community / External | [[tags/audience-community]] |
+
+## Adding a new repo
+
+1. Copy any existing repo page in this folder
+2. Update the frontmatter: title, description, and tags (status, org, component, audience, language)
+3. Fill in the metadata table and short description
+4. Add `## Related repos` with `[[wiki-links]]` to connected repositories
+5. Commit and the site will auto-generate tag pages, graph links, and folder listings

--- a/content/resources/repo-registry/infra-bi.md
+++ b/content/resources/repo-registry/infra-bi.md
@@ -1,0 +1,20 @@
+---
+title: infra-bi
+description: Infrastructure and business intelligence systems
+tags: [repo, repo-active, org-status-im, component-infra, audience-ops]
+aliases: [infra-bi]
+---
+
+| | |
+|---|---|
+| **GitHub** | [status-im/infra-bi](https://github.com/status-im/infra-bi) |
+| **Status** | Active |
+| **Org** | status-im |
+| **Language** | Mixed |
+
+Infrastructure and business intelligence systems for the IFT ecosystem. Provides dashboards, analytics, and monitoring capabilities.
+
+## Related repos
+
+- [[data-docs]] — documentation for data systems
+- [[status-network-monorepo]] — network infrastructure monitored by BI

--- a/content/resources/repo-registry/libchat.md
+++ b/content/resources/repo-registry/libchat.md
@@ -1,0 +1,25 @@
+---
+title: libchat
+description: Core chat SDK library for the Logos messaging stack
+tags: [repo, repo-active, org-logos-messaging, component-messaging, audience-dev, lang-nim]
+aliases: [libchat]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-messaging/libchat](https://github.com/logos-messaging/libchat) |
+| **Status** | Active |
+| **Org** | logos-messaging (formerly Waku) |
+| **Language** | Nim |
+
+Core chat SDK/library for the Logos messaging stack. Provides the protocol implementation for chat functionality including message delivery, group management, and encryption.
+
+## Related repos
+
+- [[chat-proto]] — protobuf definitions for the chat protocol
+- [[logos-chatsdk-module]] — Logos module wrapping libchat for the runtime
+- [[logos-chat-ui]] — UI module that consumes the chat SDK
+- [[logos-delivery-module]] — message delivery integration
+- [[logos-delivery]] — delivery service backend
+- [[rfc-index]] — protocol specifications that libchat implements
+- [[de-mls]] — encryption protocol used for group messaging

--- a/content/resources/repo-registry/logos-accounts-ui.md
+++ b/content/resources/repo-registry/logos-accounts-ui.md
@@ -1,0 +1,20 @@
+---
+title: logos-accounts-ui
+description: Accounts and identity module for the Logos application
+tags: [repo, repo-active, org-logos-co, component-ui, audience-dev, lang-typescript]
+aliases: [accounts-ui]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-accounts-ui](https://github.com/logos-co/logos-accounts-ui) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | TypeScript |
+
+Accounts and identity management module for the Logos application. Handles user profiles, identity creation, and account settings.
+
+## Related repos
+
+- [[logos-basecamp]] — host application that loads this module
+- [[logos-design-system]] — shared UI components

--- a/content/resources/repo-registry/logos-app-poc.md
+++ b/content/resources/repo-registry/logos-app-poc.md
@@ -1,0 +1,20 @@
+---
+title: logos-app-poc
+description: Original proof-of-concept application (superseded by logos-basecamp)
+tags: [repo, repo-archived, org-logos-co, component-core, component-ui, audience-dev, lang-cpp]
+aliases: [app-poc]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-app-poc](https://github.com/logos-co/logos-app-poc) |
+| **Status** | Archived |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Original proof-of-concept for the Logos application. Superseded by logos-basecamp which evolved from this POC into the production application.
+
+## Related repos
+
+- [[logos-basecamp]] — successor to this POC
+- [[logos-liblogos]] — runtime used by both POC and Basecamp

--- a/content/resources/repo-registry/logos-basecamp.md
+++ b/content/resources/repo-registry/logos-basecamp.md
@@ -1,0 +1,25 @@
+---
+title: logos-basecamp
+description: Main Logos application that hosts the modular runtime
+tags: [repo, repo-active, org-logos-co, component-core, component-ui, audience-dev, audience-community, lang-cpp]
+aliases: [basecamp, logos-app]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-basecamp](https://github.com/logos-co/logos-basecamp) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+The main Logos application (formerly logos-app-poc). Hosts the liblogos microkernel runtime and loads UI modules for chat, wallet, storage, and other features. This is the end-user-facing application that ties the ecosystem together.
+
+## Related repos
+
+- [[logos-liblogos]] — core runtime library this application is built on
+- [[logos-chat-ui]] — chat interface module loaded by Basecamp
+- [[logos-wallet-ui]] — wallet interface module
+- [[logos-accounts-ui]] — accounts/identity module
+- [[logos-storage-ui]] — storage/file management module
+- [[logos-design-system]] — shared UI components and design tokens
+- [[logos-package-manager-module]] — package discovery/installation within the app

--- a/content/resources/repo-registry/logos-blockchain-module.md
+++ b/content/resources/repo-registry/logos-blockchain-module.md
@@ -1,0 +1,22 @@
+---
+title: logos-blockchain-module
+description: Blockchain integration module for the Logos runtime
+tags: [repo, repo-active, org-logos-blockchain, component-blockchain, audience-dev, lang-cpp]
+aliases: [blockchain-module]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-blockchain/logos-blockchain-module](https://github.com/logos-blockchain/logos-blockchain-module) |
+| **Status** | Active |
+| **Org** | logos-blockchain |
+| **Language** | C++ |
+
+Runtime module that integrates blockchain capabilities into the Logos module system. Bridges the blockchain node into the microkernel architecture for wallet and dApp features.
+
+## Related repos
+
+- [[logos-blockchain]] — blockchain implementation this module wraps
+- [[logos-wallet-ui]] — wallet UI consuming blockchain module services
+- [[logos-liblogos]] — runtime this module loads into
+- [[logos-module]] — interface specification this implements

--- a/content/resources/repo-registry/logos-blockchain.md
+++ b/content/resources/repo-registry/logos-blockchain.md
@@ -1,0 +1,22 @@
+---
+title: logos-blockchain
+description: Logos blockchain implementation
+tags: [repo, repo-active, org-logos-blockchain, component-blockchain, audience-dev, audience-researcher]
+aliases: [logos-blockchain]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-blockchain/logos-blockchain](https://github.com/logos-blockchain/logos-blockchain) |
+| **Status** | Active |
+| **Org** | logos-blockchain |
+| **Language** | Mixed |
+
+Core implementation of the Logos blockchain. Provides consensus, state management, and chain execution for the Logos network.
+
+## Related repos
+
+- [[logos-blockchain-module]] — runtime module integrating the blockchain into Logos
+- [[lssa]] — Logos blockchain consensus implementation
+- [[logos-wallet-ui]] — wallet UI for interacting with the blockchain
+- [[status-network-monorepo]] — related network infrastructure

--- a/content/resources/repo-registry/logos-capability-module.md
+++ b/content/resources/repo-registry/logos-capability-module.md
@@ -1,0 +1,20 @@
+---
+title: logos-capability-module
+description: Capability discovery protocol module for Logos
+tags: [repo, repo-active, org-logos-co, component-core, audience-dev, lang-cpp]
+aliases: [capability-module]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-capability-module](https://github.com/logos-co/logos-capability-module) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Capability discovery protocol module for the Logos runtime. Enables modules to advertise and discover capabilities across the module ecosystem at runtime.
+
+## Related repos
+
+- [[logos-liblogos]] — runtime this module operates within
+- [[logos-module]] — interface specification this implements

--- a/content/resources/repo-registry/logos-chat-ui.md
+++ b/content/resources/repo-registry/logos-chat-ui.md
@@ -1,0 +1,22 @@
+---
+title: logos-chat-ui
+description: Chat interface module for the Logos application
+tags: [repo, repo-active, org-logos-co, component-ui, component-messaging, audience-dev, lang-typescript]
+aliases: [chat-ui]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-chat-ui](https://github.com/logos-co/logos-chat-ui) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | TypeScript |
+
+Chat interface module for the Logos application. Provides the user-facing chat experience including conversations, group messaging, and message history.
+
+## Related repos
+
+- [[logos-chatsdk-module]] — chat SDK integration this UI consumes
+- [[libchat]] — underlying chat library
+- [[logos-basecamp]] — host application that loads this module
+- [[logos-design-system]] — shared UI components

--- a/content/resources/repo-registry/logos-chatsdk-module.md
+++ b/content/resources/repo-registry/logos-chatsdk-module.md
@@ -1,0 +1,22 @@
+---
+title: logos-chatsdk-module
+description: Chat SDK integration module for the Logos runtime
+tags: [repo, repo-active, org-logos-co, component-messaging, audience-dev, lang-cpp]
+aliases: [chatsdk-module]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-chatsdk-module](https://github.com/logos-co/logos-chatsdk-module) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Runtime module that integrates the libchat SDK into the Logos module system. Bridges the chat library into the microkernel architecture so UI modules can access chat functionality.
+
+## Related repos
+
+- [[libchat]] — chat SDK this module wraps
+- [[logos-chat-ui]] — UI module that consumes this SDK module
+- [[logos-liblogos]] — runtime this module loads into
+- [[logos-module]] — interface specification this implements

--- a/content/resources/repo-registry/logos-cpp-sdk.md
+++ b/content/resources/repo-registry/logos-cpp-sdk.md
@@ -1,0 +1,21 @@
+---
+title: logos-cpp-sdk
+description: C++ SDK for developing Logos modules
+tags: [repo, repo-active, org-logos-co, component-core, component-tooling, audience-dev, lang-cpp]
+aliases: [cpp-sdk]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-cpp-sdk](https://github.com/logos-co/logos-cpp-sdk) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+C++ SDK that wraps logos-liblogos to simplify module development. Provides higher-level APIs, utilities, and abstractions for building Logos modules without directly interfacing with the microkernel.
+
+## Related repos
+
+- [[logos-liblogos]] — core runtime this SDK wraps
+- [[logos-module]] — module interface this SDK helps implement
+- [[logos-module-builder]] — scaffolding that generates SDK-based projects

--- a/content/resources/repo-registry/logos-delivery-module.md
+++ b/content/resources/repo-registry/logos-delivery-module.md
@@ -1,0 +1,21 @@
+---
+title: logos-delivery-module
+description: Message delivery integration module for Logos
+tags: [repo, repo-active, org-logos-co, component-messaging, audience-dev, lang-cpp]
+aliases: [delivery-module]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-delivery-module](https://github.com/logos-co/logos-delivery-module) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Message delivery integration module for the Logos runtime. Bridges delivery service functionality into the module system for reliable message transport.
+
+## Related repos
+
+- [[logos-delivery]] — delivery service backend this module integrates
+- [[libchat]] — chat library that uses delivery
+- [[logos-liblogos]] — runtime this module loads into

--- a/content/resources/repo-registry/logos-delivery.md
+++ b/content/resources/repo-registry/logos-delivery.md
@@ -1,0 +1,21 @@
+---
+title: logos-delivery
+description: Message delivery service backend
+tags: [repo, repo-active, org-logos-messaging, component-messaging, audience-dev, audience-ops, lang-nim]
+aliases: [logos-delivery]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-messaging/logos-delivery](https://github.com/logos-messaging/logos-delivery) |
+| **Status** | Active |
+| **Org** | logos-messaging |
+| **Language** | Nim |
+
+Message delivery service backend for the Logos messaging stack. Handles reliable message routing, store-and-forward, and delivery guarantees.
+
+## Related repos
+
+- [[logos-delivery-module]] — runtime module that integrates this service
+- [[libchat]] — chat library that depends on delivery
+- [[nim-libp2p]] — networking layer used for transport

--- a/content/resources/repo-registry/logos-design-system.md
+++ b/content/resources/repo-registry/logos-design-system.md
@@ -1,0 +1,24 @@
+---
+title: logos-design-system
+description: Shared UI components and design tokens for Logos applications
+tags: [repo, repo-active, org-logos-co, component-ui, audience-dev, lang-typescript]
+aliases: [design-system]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-design-system](https://github.com/logos-co/logos-design-system) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | TypeScript |
+
+Shared UI components and design tokens used across Logos applications. Ensures visual consistency across all UI modules and web properties.
+
+## Related repos
+
+- [[logos-basecamp]] — primary consumer of the design system
+- [[logos-chat-ui]] — chat UI built with these components
+- [[logos-wallet-ui]] — wallet UI built with these components
+- [[logos-accounts-ui]] — accounts UI built with these components
+- [[logos-storage-ui]] — storage UI built with these components
+- [[logos-press-engine]] — press engine referencing design tokens

--- a/content/resources/repo-registry/logos-docs.md
+++ b/content/resources/repo-registry/logos-docs.md
@@ -1,0 +1,22 @@
+---
+title: logos-docs
+description: Official Logos documentation site
+tags: [repo, repo-active, org-logos-co, component-docs, audience-dev, audience-community, lang-typescript]
+aliases: [logos-docs]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-docs](https://github.com/logos-co/logos-docs) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | TypeScript |
+
+Official documentation repository for the Logos ecosystem. Hosts developer guides, API references, architecture overviews, and onboarding materials.
+
+## Related repos
+
+- [[rfc-index]] — protocol-level specifications referenced by docs
+- [[logos-liblogos]] — core runtime documented here
+- [[logos-cpp-sdk]] — SDK documentation
+- [[logos-press-engine]] — separate content/blog engine

--- a/content/resources/repo-registry/logos-lez-rln.md
+++ b/content/resources/repo-registry/logos-lez-rln.md
@@ -1,0 +1,20 @@
+---
+title: logos-lez-rln
+description: RLN (Rate Limiting Nullifier) membership allocation service
+tags: [repo, repo-active, org-logos-co, component-core, audience-dev, audience-researcher, lang-rust]
+aliases: [lez-rln, rln]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-lez-rln](https://github.com/logos-co/logos-lez-rln) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | Rust |
+
+RLN (Rate Limiting Nullifier) membership allocation service. Provides spam protection and rate limiting through zero-knowledge proof-based membership verification.
+
+## Related repos
+
+- [[zerokit]] — ZK proof cryptography library used by RLN
+- [[rfc-index]] — RLN protocol specification

--- a/content/resources/repo-registry/logos-liblogos.md
+++ b/content/resources/repo-registry/logos-liblogos.md
@@ -1,0 +1,23 @@
+---
+title: logos-liblogos
+description: Core microkernel runtime for the Logos tech stack
+tags: [repo, repo-active, org-logos-co, component-core, audience-dev, lang-cpp]
+aliases: [liblogos]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-liblogos](https://github.com/logos-co/logos-liblogos) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Core microkernel runtime for the Logos tech stack. Provides module lifecycle management, IPC between modules via Qt Remote Objects, and the host process that orchestrates the modular application architecture.
+
+## Related repos
+
+- [[logos-basecamp]] — primary consumer application built on this runtime
+- [[logos-cpp-sdk]] — C++ SDK that wraps liblogos for module developers
+- [[logos-module]] — module interface specification that liblogos implements
+- [[logos-module-builder]] — scaffolding tool for creating new modules
+- [[logos-capability-module]] — capability discovery protocol running on this runtime

--- a/content/resources/repo-registry/logos-module-builder.md
+++ b/content/resources/repo-registry/logos-module-builder.md
@@ -1,0 +1,21 @@
+---
+title: logos-module-builder
+description: Template and scaffolding tool for creating new Logos modules
+tags: [repo, repo-active, org-logos-co, component-tooling, audience-dev, lang-cpp]
+aliases: [module-builder]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-module-builder](https://github.com/logos-co/logos-module-builder) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Template and scaffolding tool for creating new Logos modules. Generates project structure, boilerplate, and build configuration for module development.
+
+## Related repos
+
+- [[logos-module]] — interface specification the generated modules implement
+- [[logos-cpp-sdk]] — SDK used in generated module projects
+- [[logos-liblogos]] — runtime the generated modules target

--- a/content/resources/repo-registry/logos-module-viewer.md
+++ b/content/resources/repo-registry/logos-module-viewer.md
@@ -1,0 +1,20 @@
+---
+title: logos-module-viewer
+description: Inspection tool for Logos modules
+tags: [repo, repo-active, org-logos-co, component-tooling, audience-dev, lang-cpp]
+aliases: [module-viewer]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-module-viewer](https://github.com/logos-co/logos-module-viewer) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Module inspection tool for debugging and analyzing Logos modules. Allows developers to examine module metadata, interfaces, and runtime behavior.
+
+## Related repos
+
+- [[logos-module]] — interface specification of the modules being inspected
+- [[logos-liblogos]] — runtime that loads the modules

--- a/content/resources/repo-registry/logos-module.md
+++ b/content/resources/repo-registry/logos-module.md
@@ -1,0 +1,22 @@
+---
+title: logos-module
+description: Module interface specification for the Logos runtime
+tags: [repo, repo-active, org-logos-co, component-core, audience-dev, lang-cpp]
+aliases: [logos-module]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-module](https://github.com/logos-co/logos-module) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Defines the module interface specification that all Logos runtime modules must implement. The contract between the microkernel and loadable modules.
+
+## Related repos
+
+- [[logos-liblogos]] — runtime that loads modules conforming to this interface
+- [[logos-module-builder]] — scaffolding tool that generates new modules from this spec
+- [[logos-cpp-sdk]] — SDK that simplifies implementing this interface
+- [[rfc-index]] — formal specification documents

--- a/content/resources/repo-registry/logos-package-manager-module.md
+++ b/content/resources/repo-registry/logos-package-manager-module.md
@@ -1,0 +1,21 @@
+---
+title: logos-package-manager-module
+description: Runtime module for package discovery and installation within Logos
+tags: [repo, repo-active, org-logos-co, component-tooling, component-ui, audience-dev, lang-cpp]
+aliases: [package-manager-module]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-package-manager-module](https://github.com/logos-co/logos-package-manager-module) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Runtime module that provides package discovery and installation capabilities within the Logos application. Allows users to browse, install, and manage modules from within Basecamp.
+
+## Related repos
+
+- [[logos-package-manager]] — CLI tool this module wraps
+- [[logos-package]] — package format
+- [[logos-basecamp]] — host application that loads this module

--- a/content/resources/repo-registry/logos-package-manager.md
+++ b/content/resources/repo-registry/logos-package-manager.md
@@ -1,0 +1,21 @@
+---
+title: logos-package-manager
+description: CLI tool for managing Logos module packages
+tags: [repo, repo-active, org-logos-co, component-tooling, audience-dev, lang-cpp]
+aliases: [package-manager]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-package-manager](https://github.com/logos-co/logos-package-manager) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+CLI tool for discovering, installing, updating, and managing Logos module packages. Works with the package format defined in logos-package.
+
+## Related repos
+
+- [[logos-package]] — package format and build tooling
+- [[logos-package-manager-module]] — runtime module version of this tool
+- [[logos-liblogos]] — runtime that hosts installed modules

--- a/content/resources/repo-registry/logos-package.md
+++ b/content/resources/repo-registry/logos-package.md
@@ -1,0 +1,21 @@
+---
+title: logos-package
+description: Portable package building and distribution for Logos modules
+tags: [repo, repo-active, org-logos-co, component-tooling, audience-dev, lang-cpp]
+aliases: [logos-package]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-package](https://github.com/logos-co/logos-package) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Handles portable package building and distribution for Logos modules. Defines the packaging format and build tooling for creating distributable module bundles.
+
+## Related repos
+
+- [[logos-package-manager]] — CLI tool that consumes these packages
+- [[logos-package-manager-module]] — runtime module for package discovery/installation
+- [[logos-module-builder]] — generates module projects that build into packages

--- a/content/resources/repo-registry/logos-press-engine.md
+++ b/content/resources/repo-registry/logos-press-engine.md
@@ -1,0 +1,20 @@
+---
+title: logos-press-engine
+description: Content publishing and blog engine for Logos properties
+tags: [repo, repo-active, org-acid-info, component-docs, audience-community, lang-typescript]
+aliases: [press-engine, lpe]
+---
+
+| | |
+|---|---|
+| **GitHub** | [acid-info/logos-press-engine](https://github.com/acid-info/logos-press-engine) |
+| **Status** | Active |
+| **Org** | acid-info |
+| **Language** | TypeScript |
+
+Content publishing and blog engine used for Logos web properties. Powers the public-facing content sites for the ecosystem.
+
+## Related repos
+
+- [[logos-docs]] — official documentation site (separate from blog/press content)
+- [[logos-design-system]] — shared design tokens and components

--- a/content/resources/repo-registry/logos-storage-module.md
+++ b/content/resources/repo-registry/logos-storage-module.md
@@ -1,0 +1,22 @@
+---
+title: logos-storage-module
+description: Storage integration module for the Logos runtime
+tags: [repo, repo-active, org-logos-co, component-storage, audience-dev, lang-cpp]
+aliases: [storage-module]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-storage-module](https://github.com/logos-co/logos-storage-module) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | C++ |
+
+Runtime module that integrates storage capabilities into the Logos module system. Bridges the Codex/Logos storage backend into the microkernel architecture.
+
+## Related repos
+
+- [[logos-storage-nim]] — core storage implementation this module wraps
+- [[logos-storage-ui]] — UI module that consumes this integration
+- [[logos-liblogos]] — runtime this module loads into
+- [[logos-module]] — interface specification this implements

--- a/content/resources/repo-registry/logos-storage-nim.md
+++ b/content/resources/repo-registry/logos-storage-nim.md
@@ -1,0 +1,22 @@
+---
+title: logos-storage-nim
+description: Core Logos storage implementation in Nim (formerly Codex)
+tags: [repo, repo-active, org-logos-storage, component-storage, audience-dev, audience-researcher, lang-nim]
+aliases: [logos-storage-nim, codex]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-storage/logos-storage-nim](https://github.com/logos-storage/logos-storage-nim) |
+| **Status** | Active |
+| **Org** | logos-storage (formerly Codex) |
+| **Language** | Nim |
+
+Core implementation of the Logos decentralized storage network (formerly Codex). Provides the storage node implementation, erasure coding, proof of storage, and marketplace functionality.
+
+## Related repos
+
+- [[logos-storage-module]] — runtime module that wraps this for the Logos application
+- [[logos-storage-ui]] — UI module for storage management
+- [[logos-storage-research]] — research and privacy analysis for the storage layer
+- [[rfc-index]] — storage protocol specifications

--- a/content/resources/repo-registry/logos-storage-research.md
+++ b/content/resources/repo-registry/logos-storage-research.md
@@ -1,0 +1,20 @@
+---
+title: logos-storage-research
+description: Research and privacy analysis for the Logos storage layer
+tags: [repo, repo-active, org-logos-storage, component-storage, audience-researcher]
+aliases: [storage-research]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-storage/logos-storage-research](https://github.com/logos-storage/logos-storage-research) |
+| **Status** | Active |
+| **Org** | logos-storage |
+| **Language** | Mixed |
+
+Research repository for the Logos storage layer. Contains privacy analysis, threat modeling, academic papers, and experimental prototypes for storage protocol improvements.
+
+## Related repos
+
+- [[logos-storage-nim]] — production implementation informed by this research
+- [[rfc-index]] — specifications that incorporate research findings

--- a/content/resources/repo-registry/logos-storage-ui.md
+++ b/content/resources/repo-registry/logos-storage-ui.md
@@ -1,0 +1,22 @@
+---
+title: logos-storage-ui
+description: Storage and file management UI module for the Logos application
+tags: [repo, repo-active, org-logos-co, component-ui, component-storage, audience-dev, lang-typescript]
+aliases: [storage-ui]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-storage-ui](https://github.com/logos-co/logos-storage-ui) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | TypeScript |
+
+Storage and file management UI module for the Logos application. Provides file browsing, upload, download, and management interfaces powered by the Logos storage stack.
+
+## Related repos
+
+- [[logos-storage-module]] — storage integration module this UI consumes
+- [[logos-storage-nim]] — core storage implementation
+- [[logos-basecamp]] — host application that loads this module
+- [[logos-design-system]] — shared UI components

--- a/content/resources/repo-registry/logos-wallet-ui.md
+++ b/content/resources/repo-registry/logos-wallet-ui.md
@@ -1,0 +1,21 @@
+---
+title: logos-wallet-ui
+description: Wallet interface module for the Logos application
+tags: [repo, repo-active, org-logos-co, component-ui, component-blockchain, audience-dev, lang-typescript]
+aliases: [wallet-ui]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/logos-wallet-ui](https://github.com/logos-co/logos-wallet-ui) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | TypeScript |
+
+Wallet interface module for the Logos application. Provides cryptocurrency wallet functionality including balance display, transaction history, and token management.
+
+## Related repos
+
+- [[logos-basecamp]] — host application that loads this module
+- [[logos-design-system]] — shared UI components
+- [[logos-blockchain]] — blockchain integration

--- a/content/resources/repo-registry/lssa.md
+++ b/content/resources/repo-registry/lssa.md
@@ -1,0 +1,20 @@
+---
+title: lssa
+description: Logos blockchain consensus implementation
+tags: [repo, repo-active, org-logos-blockchain, component-blockchain, audience-dev, audience-researcher]
+aliases: [lssa]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-blockchain/lssa](https://github.com/logos-blockchain/lssa) |
+| **Status** | Active |
+| **Org** | logos-blockchain |
+| **Language** | Mixed |
+
+Logos blockchain consensus implementation. Provides the consensus protocol and agreement mechanism for the Logos blockchain network.
+
+## Related repos
+
+- [[logos-blockchain]] — blockchain implementation using this consensus
+- [[rfc-index]] — consensus protocol specifications

--- a/content/resources/repo-registry/nim-libp2p.md
+++ b/content/resources/repo-registry/nim-libp2p.md
@@ -1,0 +1,22 @@
+---
+title: nim-libp2p
+description: Nim implementation of the libp2p networking stack
+tags: [repo, repo-active, org-vacp2p, component-core, component-messaging, audience-dev, audience-researcher, lang-nim]
+aliases: [nim-libp2p]
+---
+
+| | |
+|---|---|
+| **GitHub** | [vacp2p/nim-libp2p](https://github.com/vacp2p/nim-libp2p) |
+| **Status** | Active |
+| **Org** | vacp2p |
+| **Language** | Nim |
+
+Nim implementation of the libp2p networking stack. Provides peer-to-peer networking, transport protocols, pubsub, and discovery used across the Logos ecosystem for node communication.
+
+## Related repos
+
+- [[libchat]] — chat library built on nim-libp2p networking
+- [[logos-delivery]] — delivery service using libp2p transport
+- [[logos-storage-nim]] — storage nodes using libp2p networking
+- [[rfc-index]] — libp2p-related specifications

--- a/content/resources/repo-registry/nim-sds.md
+++ b/content/resources/repo-registry/nim-sds.md
@@ -1,0 +1,20 @@
+---
+title: nim-sds
+description: Nim secure data structures library
+tags: [repo, repo-active, org-logos-messaging, component-messaging, audience-dev, audience-researcher, lang-nim]
+aliases: [nim-sds]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-messaging/nim-sds](https://github.com/logos-messaging/nim-sds) |
+| **Status** | Active |
+| **Org** | logos-messaging |
+| **Language** | Nim |
+
+Nim implementation of secure data structures for the messaging stack. Provides cryptographically verified data structures used in messaging protocols.
+
+## Related repos
+
+- [[libchat]] — chat library that uses these data structures
+- [[nim-libp2p]] — networking library in the same Nim ecosystem

--- a/content/resources/repo-registry/rfc-index.md
+++ b/content/resources/repo-registry/rfc-index.md
@@ -1,0 +1,23 @@
+---
+title: rfc-index
+description: Central specification and RFC repository for all IFT protocols
+tags: [repo, repo-active, org-vacp2p, component-docs, audience-dev, audience-researcher]
+aliases: [rfc-index, specs, rfcs]
+---
+
+| | |
+|---|---|
+| **GitHub** | [vacp2p/rfc-index](https://github.com/vacp2p/rfc-index) |
+| **Status** | Active |
+| **Org** | vacp2p |
+| **Language** | Markdown |
+
+The central hub for all IFT protocol specifications and RFCs. Houses specifications for Waku, Codex, Nimbus, Status, and cross-cutting protocols. This is the authoritative source for protocol-level documentation across the ecosystem.
+
+## Related repos
+
+- [[libchat]] — implements chat protocol specs from this repo
+- [[nim-libp2p]] — implements networking specs
+- [[de-mls]] — implements Double-Ratchet MLS protocol spec
+- [[logos-module]] — module interface spec lives here
+- [[logos-docs]] — higher-level documentation that references these specs

--- a/content/resources/repo-registry/roadmap.md
+++ b/content/resources/repo-registry/roadmap.md
@@ -1,0 +1,20 @@
+---
+title: roadmap
+description: Logos project roadmap
+tags: [repo, repo-active, org-logos-co, component-docs, audience-dev, audience-community]
+aliases: [logos-roadmap]
+---
+
+| | |
+|---|---|
+| **GitHub** | [logos-co/roadmap](https://github.com/logos-co/roadmap) |
+| **Status** | Active |
+| **Org** | logos-co |
+| **Language** | Markdown |
+
+The Logos project roadmap. Tracks high-level milestones, deliverables, and timelines across the ecosystem.
+
+## Related repos
+
+- [[logos-docs]] — documentation that references roadmap items
+- [[anoncomms-pm]] — project-specific milestone tracking

--- a/content/resources/repo-registry/status-network-monorepo.md
+++ b/content/resources/repo-registry/status-network-monorepo.md
@@ -1,0 +1,20 @@
+---
+title: status-network-monorepo
+description: SNT network and blockchain implementations
+tags: [repo, repo-active, org-status-im, component-blockchain, component-infra, audience-dev, lang-go]
+aliases: [status-network-monorepo, snt-monorepo]
+---
+
+| | |
+|---|---|
+| **GitHub** | [status-im/status-network-monorepo](https://github.com/status-im/status-network-monorepo) |
+| **Status** | Active |
+| **Org** | status-im |
+| **Language** | Go |
+
+Monorepo for the Status Network Token (SNT) network and associated blockchain implementations. Contains smart contracts, network nodes, and blockchain infrastructure.
+
+## Related repos
+
+- [[logos-blockchain]] — Logos blockchain implementation
+- [[infra-bi]] — infrastructure and analytics

--- a/content/resources/repo-registry/zerokit.md
+++ b/content/resources/repo-registry/zerokit.md
@@ -1,0 +1,21 @@
+---
+title: zerokit
+description: Zero-knowledge proof cryptography library
+tags: [repo, repo-active, org-vacp2p, component-core, audience-dev, audience-researcher, lang-rust]
+aliases: [zerokit]
+---
+
+| | |
+|---|---|
+| **GitHub** | [vacp2p/zerokit](https://github.com/vacp2p/zerokit) |
+| **Status** | Active |
+| **Org** | vacp2p |
+| **Language** | Rust |
+
+Zero-knowledge proof cryptography library. Provides ZK proof generation and verification primitives used for RLN (Rate Limiting Nullifier), anonymous credentials, and privacy-preserving protocols.
+
+## Related repos
+
+- [[logos-lez-rln]] — RLN service built on zerokit
+- [[rfc-index]] — ZK-related protocol specifications
+- [[de-mls]] — encryption protocol in the same privacy toolchain

--- a/content/site-plan/index.md
+++ b/content/site-plan/index.md
@@ -18,3 +18,4 @@ Here are the following sections of this site that need to be built out and a sho
 - [[resources/index|Resource Map]]
 - [[Coordination Proposals]]
 - [[Content Tracker]]
+- [[resources/repo-registry/index|Repository Registry]]


### PR DESCRIPTION
## Summary
- Adds a new **Repository Registry** section under `resources/repo-registry/` with 42 structured stub pages covering all known IFT repositories across 7 GitHub organizations
- Each repo page has metadata (status, org, language), description, and `[[wiki-links]]` to related repos — enabling Quartz's graph visualization and backlinks for the interaction map
- Tag taxonomy with prefixed tags (`repo-*`, `org-*`, `component-*`, `audience-*`, `lang-*`) provides multi-axis browsing via auto-generated tag pages
- Updates `Github.md` with link to registry and missing orgs; adds registry to site plan

## What this enables
- Browse repos by status, organization, component domain, target audience, or language
- See dependency/relationship graph between repos via Quartz's built-in graph panel
- Full-text search across all repo descriptions
- Easy maintenance — adding a repo is copying a template and filling in tags

## Test plan
- [ ] Run `npx quartz build --serve` and verify the registry folder page lists all repos
- [ ] Check tag pages work (e.g., `/tags/repo`, `/tags/org-logos-co`, `/tags/component-core`)
- [ ] Verify graph visualization shows connections on individual repo pages
- [ ] Confirm backlinks panel shows reverse relationships
- [ ] Verify Explorer sidebar includes the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)